### PR TITLE
Start mongodb as master via docker-compose

### DIFF
--- a/examples/todos/docker-compose.yml
+++ b/examples/todos/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - /data:/data/db
     expose:
       - "27017"
-    command: --noprealloc --smallfiles --replSet rs0
+    command: --noprealloc --smallfiles
     restart: always
 
   webapp:


### PR DESCRIPTION
The example was not working as MongoDB started in replica set and application is setup to read from masters.